### PR TITLE
Supporting ironmen and chat channel ranks for player renaming

### DIFF
--- a/src/main/java/com/rewordmanager/RewordManagerPlugin.java
+++ b/src/main/java/com/rewordmanager/RewordManagerPlugin.java
@@ -111,11 +111,11 @@ public class RewordManagerPlugin extends Plugin {
 
 		String modifiedName = playerListHashMap.getOrDefault(player, player);
 
-		if (player.equals(modifiedName)) {
-			builder.append(ChatColorType.HIGHLIGHT).append("<Modified> ");
+		if (!player.equals(modifiedName)) {
+			builder.append(ChatColorType.HIGHLIGHT).append("<" + modifiedName + "> ");
 		}
 		else {
-			builder.append(ChatColorType.HIGHLIGHT).append("<" + modifiedName + "> ");
+			builder.append(ChatColorType.HIGHLIGHT).append("<Modified> ");
 		}
 
 		String[] words = message.split("\\s");

--- a/src/main/java/com/rewordmanager/RewordManagerPlugin.java
+++ b/src/main/java/com/rewordmanager/RewordManagerPlugin.java
@@ -98,7 +98,7 @@ public class RewordManagerPlugin extends Plugin {
 		MessageNode messageNode = chatMessage.getMessageNode();
 
 		String message = messageNode.getValue();
-		String player = messageNode.getName();
+		String player = messageNode.getName().replaceAll("<.*?>", "");
 		String clan = messageNode.getSender();
 
 		if (!checkMessage(message) && !checkPlayer(player) && !checkClan(clan)) {
@@ -106,11 +106,17 @@ public class RewordManagerPlugin extends Plugin {
 		}
 
 		final ChatMessageBuilder builder = new ChatMessageBuilder();
-		builder.append(ChatColorType.HIGHLIGHT).append("[Modified] ");
 
 		messageNode.setSender(clanListHashMap.getOrDefault(clan, clan));
 
-		messageNode.setName(playerListHashMap.getOrDefault(player, player));
+		String modifiedName = playerListHashMap.getOrDefault(player, player);
+
+		if (player.equals(modifiedName)) {
+			builder.append(ChatColorType.HIGHLIGHT).append("<Modified> ");
+		}
+		else {
+			builder.append(ChatColorType.HIGHLIGHT).append("<" + modifiedName + "> ");
+		}
 
 		String[] words = message.split("\\s");
 		for (String word : words) {


### PR DESCRIPTION
Icons that appear before names are wrapped in brackets. For ironmen this looks like: `<img=2>MyName`. If you were to put a player reword rule in that included the correct bracket value you could reword ironman names.

To accommodate for this I added a regex rule to strip out any bracket values that come before the actual name. This has successfully allowed for ironman renaming by just typing the players name.

In addition to this I noticed that renaming players broke rank icons in clan and friends chats. After talking with the runelite maintainer I learned this is because there is a script that takes the name from the chat message to compare that against the channel member list and get the correct rank icon. When you change the name that new name is not a valid name in the channel members, so it applies the default channel icon to their message.

After a lot of digging it seems like there is not a way to change the name visually, but get the internal script that applies the rank icon to use the original name. To work around this limitation I opted to replace the `Modified` text in the chat message itself with the newly defined name for that player. I changed the `[]` brackets to `<>` brackets as well because the square brackets looked weird next to some characters, such as `I`.

Here is a screenshot where you can see the channel rank icon as well as the rename value (account name and channel redacted)
![image](https://github.com/user-attachments/assets/16966ae0-0481-4647-9fc8-ee63bdb72f0c)
